### PR TITLE
When running on Debian, use its service management facilities

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,17 +41,17 @@ class prosody(
   Optional[String]                        $ssl_protocol = undef,
 ) {
   if ($community_modules != []) {
-    class { '::prosody::community_modules':
+    class { 'prosody::community_modules':
       require => Class['::prosody::package'],
       before  => Class['::prosody::config'],
     }
   }
 
   anchor { 'prosody::begin': }
-  -> class { '::prosody::package': }
-  -> class { '::prosody::config': }
-  -> class { '::prosody::service': }
-  -> anchor { '::prosody::end': }
+  -> class { 'prosody::package': }
+  -> class { 'prosody::config': }
+  -> class { 'prosody::service': }
+  -> anchor { 'prosody::end': }
 
   # create virtualhost resources via hiera
   create_resources('prosody::virtualhost', $virtualhosts, $virtualhost_defaults)

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,6 +9,13 @@ class prosody::service {
           require => Class[prosody::config],
         }
       }
+      'Debian': {
+        service { 'prosody':
+          ensure  => running,
+          enable  => true,
+          require => Class[prosody::config],
+        }
+      }
       default: {
         service { 'prosody' :
           ensure    => running,


### PR DESCRIPTION
instead of calling prosodyctl