### PR TITLE
When running on Debian, use its service management facilities

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,6 +9,13 @@ class prosody::service {
           require => Class[prosody::config],
         }
       }
+      'Debian': {
+        service { 'prosody':
+          ensure  => running,
+          enable  => true,
+          require => Class[prosody::config],
+        }
+      }
       default: {
         service { 'prosody' :
           ensure    => running,


### PR DESCRIPTION
instead of calling prosodyctl

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
