### PR TITLE
Fix user creation if domain contains a dash

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -3,7 +3,8 @@ define prosody::user(
   String        $pass,
   Prosody::Host $host = 'localhost',
 ) {
-  $dir = regsubst($host, '\.', '%2e', 'G')
+  $_dir1 = regsubst($host, '\.', '%2e', 'G')
+  $dir = regsubst($_dir1, '-', '%2d', 'G')
 
   ensure_resource('file', "/var/lib/prosody/${dir}", {
     ensure => 'directory',

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -6,6 +6,9 @@ define prosody::user(
   $_dir1 = regsubst($host, '\.', '%2e', 'G')
   $dir = regsubst($_dir1, '-', '%2d', 'G')
 
+  $_username1 = regsubst($name, '\.', '%2e', 'G')
+  $_username = regsubst($_username1, '-', '%2d', 'G')
+
   ensure_resource('file', "/var/lib/prosody/${dir}", {
     ensure => 'directory',
     owner  => 'prosody',
@@ -24,7 +27,7 @@ return {
   [\"password\"] = \"${pass}\";
 };
 "
-  file {"/var/lib/prosody/${dir}/accounts/${name}.dat":
+  file {"/var/lib/prosody/${dir}/accounts/${_username}.dat":
     owner   => 'prosody',
     group   => 'prosody',
     mode    => '0640',

--- a/spec/defines/user.rb
+++ b/spec/defines/user.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'erb'
+
+describe 'prosody::user' do
+  let(:pre_condition) do
+    'include ::prosody'
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on os #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      context 'with simple parameters' do
+        let(:params) { { name: 'bob', pass: 'pass123' } }
+
+        it {
+          is_expected.to contain_file('/var/lib/prosodoy/localhost/accounts/bob.dat').with(
+            content: '
+return {
+  [\"password\"] = \"pass123\";
+};',
+            ensure: 'present'
+          )
+        }
+      end
+      context 'with complex domain' do
+        let(:params) { { name: 'bob', pass: 'pass123', host: 'foo-bar.com' } }
+
+        it {
+          is_expected.to contain_file('/var/lib/prosodoy/foo%2dbar%2ecom/accounts/bob.dat').with(
+            content: '
+return {
+  [\"password\"] = \"pass123\";
+};',
+            ensure: 'present'
+          )
+        }
+      end
+    end
+  end
+end

--- a/spec/defines/user.rb
+++ b/spec/defines/user.rb
@@ -38,6 +38,19 @@ return {
           )
         }
       end
+      context 'with complex username' do
+        let(:params) { { name: 'bob.bar-foo', pass: 'pass123' } }
+
+        it {
+          is_expected.to contain_file('/var/lib/prosodoy/localhost/accounts/bob%2ebar%2dfoo.dat').with(
+            content: '
+return {
+  [\"password\"] = \"pass123\";
+};',
+            ensure: 'present'
+          )
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
Prosody encodes every non-word character[1], but I don't know how to
replicate this behaviour in puppet so I'm just adding the dash that I
happen to need. Without this fix, the user file is created in an
incorrect location and prosody will not use it/tell you that the user
does not exist.

[1] https://hg.prosody.im/trunk/file/f5d88ad24b30/util/datamanager.lua#l54

Signed-off-by: Florian Pritz <bluewind@xinu.at>

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
