### PR TITLE
Fix a syntax error in deeply nested custom_options.

### DIFF
--- a/templates/prosody.cfg.erb
+++ b/templates/prosody.cfg.erb
@@ -168,7 +168,7 @@ def print_recursive(object, indentation = 0)
   when Array
     '{ "' + object.join('"; "') + '" }'
   when Hash
-    "{\n" + ' ' * (indentation + 2) + object.map {|k,v| + "#{k} = " + print_recursive(v, indentation + 2)}.join(";\n" + ' ' * (indentation + 2)) + ";\n" + (' ' * indentation) + '}'
+    "{\n" + ' ' * (indentation + 2) + object.map {|k,v| "#{k} = " + print_recursive(v, indentation + 2)}.join(";\n" + ' ' * (indentation + 2)) + ";\n" + (' ' * indentation) + '}'
   when TrueClass, FalseClass
     object.to_s
   else

--- a/templates/virtualhost.cfg.erb
+++ b/templates/virtualhost.cfg.erb
@@ -23,7 +23,7 @@ def print_recursive(object, indentation = 0)
   when Array
     '{ "' + object.join('"; "') + '" }'
   when Hash
-    "{\n" + ' ' * (indentation + 2) + object.map {|k,v| + "#{k} = " + print_recursive(v, indentation + 2)}.join(";\n" + ' ' * (indentation + 2)) + ";\n" + (' ' * indentation) + '}'
+    "{\n" + ' ' * (indentation + 2) + object.map {|k,v| "#{k} = " + print_recursive(v, indentation + 2)}.join(";\n" + ' ' * (indentation + 2)) + ";\n" + (' ' * indentation) + '}'
   when TrueClass, FalseClass
     object.to_s
   else


### PR DESCRIPTION
#### Pull Request (PR) description
This fixes a syntax error in the handling of `custom_options`. Before haing a statement like this:
```
        custom_options         => {
            contact_info       => {
                'abuse'        => [ 'mailto:abuse@example.com' ],
            },
        },
```

Restulted in an error message like this:
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Failed to parse template prosody/prosody.cfg.erb:
  Filepath: /etc/puppetlabs/code/prosody/modules/prosody/templates/prosody.cfg.erb
  Line: 171
  Detail: undefined method `+@' for "abuse = ":String
 (file: /etc/puppetlabs/code/prosody/modules/prosody/manifests/config.pp, line: 14, column: 16) on node xmpp.example.com
```
