### PR TITLE
Show the loading of modules for specific components in the README example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ node myserver {
     authentication    => 'ldap',
     components => {
       'conference'        => {
-        'name' => 'conf.example.org',
-        'type' =>'muc',
+        'name'   => 'conf.example.org',
+        'type'   =>'muc',
+        'options => {
+          'modules_enabled' => [
+            'muc_mam',
+            'vcard_muc',
+          ],
       },
       'bridge'            => {
         'name'   => 'bridge.example.org',


### PR DESCRIPTION
#### Pull Request (PR) description
Some modules have to be loaded after certain `component` statements. Currently, there is no way to do this.

Examples of this are the `muc_mam` and the `vcard_muc` modules, both of which have to be loaded after the `muc` component statement. This is not explicitly stated in their documentation, however when I just load them with the other modules at the top of the file, Prosody prints an error like this:
```
Sep 19 19:04:25 modulemanager	error	Error initializing module 'vcard_muc' on 'example.com': /usr/lib64/prosody/core/moduleapi.lua:160: Unable to load required module, mod_muc: MUC should be loaded as a component, please see https://prosody.im/doc/components
stack traceback:
	[C]: in function 'error'
	/usr/lib64/prosody/modules/muc/mod_muc.lua:22: in main chunk
	[C]: in function 'xpcall'
	/usr/lib64/prosody/core/modulemanager.lua:183: in function 'do_load_module'
	/usr/lib64/prosody/core/modulemanager.lua:261: in function 'load'
	/usr/lib64/prosody/core/moduleapi.lua:158: in function 'depends'
	...dy/community modules/mod_vcard_muc/mod_vcard_muc.lua:15: in main chunk
	[C]: in function 'xpcall'
	/usr/lib64/prosody/core/modulemanager.lua:183: in function 'do_load_module'
	/usr/lib64/prosody/core/modulemanager.lua:261: in function 'load'
	/usr/lib64/prosody/core/modulemanager.lua:83: in function '?'
	/usr/lib64/prosody/util/events.lua:79: in function </usr/lib64/prosody/util/events.lua:75>
	(tail call): ?
	/usr/lib64/prosody/core/hostmanager.lua:108: in function 'activate'
	/usr/lib64/prosody/core/hostmanager.lua:58: in function '?'
	/usr/lib64/prosody/util/events.lua:79: in function </usr/lib64/prosody/util/events.lua:75>
	(tail call): ?
	/usr/lib64/prosody/util/startup.lua:399: in function 'prepare_to_start'
	/usr/lib64/prosody/util/startup.lua:635: in function 'f'
	/usr/lib64/prosody/util/async.lua:139: in function 'func'
	/usr/lib64/prosody/util/async.lua:127: in function </usr/lib64/prosody/util/async.lua:125>
stack traceback:
	[C]: in function 'error'
	/usr/lib64/prosody/core/moduleapi.lua:160: in function 'depends'
	...dy/community-modules/mod_vcard_muc/mod_vcard_muc.lua:15: in main chunk
	[C]: in function 'xpcall'
	/usr/lib64/prosody/core/modulemanager.lua:183: in function 'do_load_module'
	/usr/lib64/prosody/core/modulemanager.lua:261: in function 'load'
	/usr/lib64/prosody/core/modulemanager.lua:83: in function '?'
	/usr/lib64/prosody/util/events.lua:79: in function </usr/lib64/prosody/util/events.lua:75>
	(tail call): ?
	/usr/lib64/prosody/core/hostmanager.lua:108: in function 'activate'
	/usr/lib64/prosody/core/hostmanager.lua:58: in function '?'
	/usr/lib64/prosody/util/events.lua:79: in function </usr/lib64/prosody/util/events.lua:75>
	(tail call): ?
	/usr/lib64/prosody/util/startup.lua:399: in function 'prepare_to_start'
	/usr/lib64/prosody/util/startup.lua:635: in function 'f'
	/usr/lib64/prosody/util/async.lua:139: in function 'func'
```