### PR TITLE
add support for Debian (buster/bullseye)

### DIFF
--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,0 +1,41 @@
+---
+# defaults for Debian
+
+prosody::daemonize: false
+prosody::pidfile: '/run/prosody/prosody.pid'
+prosody::s2s_secure_auth: false
+prosody::authentication: 'internal_hashed'
+prosody::ssl_custom_config: false
+prosody::custom_options:
+  limits:
+    c2s:
+      rate: "10kb/s"
+    s2sin:
+      rate: "30kb/s"
+  certificates: "certs"
+  archive_expires_after: "1w"
+
+prosody::log_sinks: []
+prosody::log_advanced:
+  error: 'syslog'
+
+prosody::modules_base:
+  - admin_adhoc
+  - dialback
+  - disco
+  - pep
+  - ping
+  - posix
+  - private
+  - roster
+  - saslauth
+  - time
+  - tls
+  - vcard4
+  - uptime
+  - version
+  - carbons
+  - blocklist
+  - vcard_legacy
+  - limits
+  - register

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,5 +1,11 @@
 ---
 version: 5
 hierarchy:
+  - name: "osname/major release"
+    paths:
+      - "os/%{facts.os.name}/%{facts.os.release.major}.yaml"
+  - name: "osname"
+    paths:
+      - "os/%{facts.os.name}.yaml"
   - name: common
     path: common.yaml

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,13 @@
         "18.04",
         "20.04"
       ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "10",
+        "11"
+      ]
     }
   ],
   "dependencies": [


### PR DESCRIPTION
#### Pull Request (PR) description
Add support for Debian buster and bullseye by adding hiera defaults that give an equal configuration
as with the installed prosody package.

#### This Pull Request (PR) fixes the following issues
n/a