### PR TITLE
fix template to display of component options

### DIFF
--- a/spec/defines/virtualhost_spec.rb
+++ b/spec/defines/virtualhost_spec.rb
@@ -96,6 +96,18 @@ describe 'prosody::virtualhost' do
         }
       end
 
+      context 'with deeply nested component options' do
+        let(:params) { { components: { 'comp1' => { 'type' => 'muc', 'options' => { 'bo' => true, 'arr' => %w[one two], 'str' => 'string' } } } } }
+
+        it {
+          is_expected.to contain_file(path_avail). \
+            with_content(%r{^Component "comp1" "muc"$}). \
+            with_content(%r{^  bo = true;$}). \
+            with_content(%r{^  arr = { "one"; "two" };$}).\
+            with_content(%r{^  str = "string";$})
+        }
+      end
+
       context 'with disco items' do
         let(:params) { { disco_items: %w[foo bar] } }
 

--- a/templates/virtualhost.cfg.erb
+++ b/templates/virtualhost.cfg.erb
@@ -49,7 +49,7 @@ Component "<%= name %>" <% if component.include?('type') then %>"<%= component['
   <%- end -%>
   <%- if component.include?('options') -%>
     <%- component['options'].sort.each do |k, v| -%>
-  <%= k %> = <%= v %>;
+  <%= k %> = <%= print_recursive(v) %>;
     <%- end -%>
   <%- end -%>
 <% end -%>


### PR DESCRIPTION
#### Pull Request (PR) description
if a component option is an array, it could not be displayed
correct (used [] instead of {})

#### This Pull Request (PR) fixes the following issues
Fixes #84

