### PR TITLE
fix virtualhost missing $config_requires if $ssl_copy is false

### DIFF
--- a/manifests/virtualhost.pp
+++ b/manifests/virtualhost.pp
@@ -47,6 +47,7 @@ define prosody::virtualhost (
   elsif (($ssl_key != undef) and ($ssl_cert != undef) and ($ssl_copy == false)) {
     $prosody_ssl_key  = $ssl_key
     $prosody_ssl_cert = $ssl_cert
+    $config_requires = Class['prosody::package']
   }
 
   else {

--- a/spec/defines/virtualhost_spec.rb
+++ b/spec/defines/virtualhost_spec.rb
@@ -66,6 +66,19 @@ describe 'prosody::virtualhost' do
         }
       end
 
+      context 'with ssl keys and certs but no copy' do
+        let(:ssl_key) { '/etc/prosody/certs/rspec-puppet.com.key' }
+        let(:ssl_cert) { '/etc/prosody/certs/rspec-puppet.com.crt' }
+        let(:params) { { ssl_key: ssl_key, ssl_cert: ssl_cert, ssl_copy: false } }
+
+        it {
+          is_expected.to contain_file(path_avail).with(
+            ensure: 'present',
+            require: ['Class[Prosody::Package]']
+          )
+        }
+      end
+
       context 'ensure => absent' do
         let(:params) { { ensure: 'absent' } }
 


### PR DESCRIPTION
#### Pull Request (PR) description
$config_requires should always be configured

#### This Pull Request (PR) fixes the following issues
n/a
