### PR TITLE
add possibility to force service and spec tests for service

### DIFF
--- a/data/Debian-family.yaml
+++ b/data/Debian-family.yaml
@@ -1,0 +1,5 @@
+---
+# Defaults for Debian os family (eg. Debian, Ubuntu etc)
+
+prosody::service::hasstatus: ~
+prosody::service::restart: ~

--- a/data/OpenBSD-family.yaml
+++ b/data/OpenBSD-family.yaml
@@ -1,0 +1,5 @@
+---
+# Defaults for OpenBSD os family
+
+prosody::service::hasstatus: ~
+prosody::service::restart: ~

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -65,3 +65,6 @@ prosody::community_modules::ensure: present
 prosody::community_modules::path: /var/lib/prosody/modules
 prosody::community_modules::source: https://hg.prosody.im/prosody-modules/
 prosody::community_modules::type: hg
+
+prosody::service::hasstatus: false
+prosody::service::restart: '/usr/bin/prosodyctl reload'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -7,5 +7,8 @@ hierarchy:
   - name: "osname"
     paths:
       - "os/%{facts.os.name}.yaml"
+  - name: "osfamily"
+    paths:
+      - "%{facts.os.family}-family.yaml"
   - name: common
     path: common.yaml

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,7 @@ class prosody (
   Optional[Stdlib::Absolutepath] $ssl_cert = undef,
   Optional[Stdlib::Absolutepath] $ssl_key = undef,
   Optional[String] $ssl_protocol = undef,
+  Optional[Boolean] $manage_service = undef,
 ) {
   if ($community_modules != []) {
     class { 'prosody::community_modules':

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,7 +4,7 @@ class prosody::service(
   Optional[String]  $restart   = undef,
 ) {
 
-  if $prosody::daemonize {
+  if pick($prosody::manage_service, $prosody::daemonize) {
     service { 'prosody':
       ensure    => running,
       enable    => true,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,29 +1,16 @@
 # == Class: prosody::service
-class prosody::service {
+class prosody::service(
+  Optional[Boolean] $hasstatus = undef,
+  Optional[String]  $restart   = undef,
+) {
+
   if $prosody::daemonize {
-    case $facts['os']['family'] {
-      'OpenBSD': {
-        service { 'prosody':
-          ensure  => running,
-          enable  => true,
-          require => Class[prosody::config],
-        }
-      }
-      'Debian': {
-        service { 'prosody':
-          ensure  => running,
-          enable  => true,
-          require => Class[prosody::config],
-        }
-      }
-      default: {
-        service { 'prosody' :
-          ensure    => running,
-          hasstatus => false,
-          restart   => '/usr/bin/prosodyctl reload',
-          require   => Class[prosody::config],
-        }
-      }
+    service { 'prosody':
+      ensure    => running,
+      enable    => true,
+      hasstatus => $hasstatus,
+      restart   => $restart,
+      require   => Class[prosody::config],
     }
   }
 }

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -42,6 +42,31 @@ describe 'prosody::service' do
 
         it_behaves_like 'prosody::service with defaults'
       end
+
+      context 'with manage=> true' do
+        let(:pre_condition) do
+          'class {"prosody":
+          manage_service => true
+        }'
+        end
+
+        it {
+          is_expected.to contain_service('prosody')
+            .with_ensure('running')
+            .with_enable(true)
+        }
+      end
+      context 'with manage => false' do
+        let(:pre_condition) do
+          'class {"prosody":
+          manage_service => false
+        }'
+        end
+
+        it {
+          is_expected.not_to contain_service('prosody')
+        }
+      end
     end
   end
 end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe 'prosody::service' do
+  let(:pre_condition) { 'include prosody' }
+
+  shared_examples 'prosody::service with defaults' do
+    it {
+      if facts[:os]['family'] == 'Debian'
+        if facts[:os]['name'] == 'Debian'
+          is_expected.not_to contain_service('prosody')
+        else
+          is_expected.to contain_service('prosody')
+            .with_ensure('running')
+            .with_enable(true)
+            .without_hasstatus
+            .without_restart
+        end
+
+      elsif facts[:os]['family'] == 'OpenBSD'
+        is_expected.not_to contain_service('prosody')
+          .with_ensure('running')
+          .with_enable(true)
+          .without_hasstatus
+          .without_restart
+      else
+        is_expected.to contain_service('prosody')
+          .with_ensure('running')
+          .with_hasstatus(false)
+          .with_restart('/usr/bin/prosodyctl reload')
+      end
+    }
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on os #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      context 'with defaults' do
+        let(:pre_condition) { 'class {"prosody": }' }
+
+        it_behaves_like 'prosody::service with defaults'
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

There are three commits, which all shall not change the current behaviour:
first add spec tests for prosody::service class, secondly simplify the prosody::service class to not have any statements depending on os facts (these should be managed with hiera).
The third one is the important one, currently service cannot be managed without setting prosody::daemonize to true. But with systemd we like to set daemonize to false (since systemd likes to run prosody in foreground) and ensure the service (eg for 
reload on new certificate etc.)

#### This Pull Request (PR) fixes the following issues
allow ensurance of prosody service with systemd.

#### Additional remark
At least on Debian bullseye (and probably buster) which both use systemd by default, we should set prosody::manage_service to true. I can do an pull request for that if you wish as soon as this one is merged.
