### PR TITLE
fix array in print_recursive function (in both templates !)

### DIFF
--- a/spec/defines/virtualhost_spec.rb
+++ b/spec/defines/virtualhost_spec.rb
@@ -116,7 +116,7 @@ describe 'prosody::virtualhost' do
           is_expected.to contain_file(path_avail). \
             with_content(%r{^Component "comp1" "muc"$}). \
             with_content(%r{^  bo = true;$}). \
-            with_content(%r{^  arr = { "one"; "two" };$}).\
+            with_content(%r{^  arr = { "one", "two" };$}).\
             with_content(%r{^  str = "string";$})
         }
       end

--- a/templates/prosody.cfg.erb
+++ b/templates/prosody.cfg.erb
@@ -166,7 +166,7 @@ s2s_secure_domains = {
 def print_recursive(object, indentation = 0)
   case object
   when Array
-    '{ "' + object.join('"; "') + '" }'
+    '{ ' + object.map {|v| print_recursive(v, 0)}.join(', ') + ' }'
   when Hash
     "{\n" + ' ' * (indentation + 2) + object.map {|k,v| "#{k} = " + print_recursive(v, indentation + 2)}.join(";\n" + ' ' * (indentation + 2)) + ";\n" + (' ' * indentation) + '}'
   when TrueClass, FalseClass

--- a/templates/virtualhost.cfg.erb
+++ b/templates/virtualhost.cfg.erb
@@ -21,7 +21,7 @@ VirtualHost "<%= @name %>"
 def print_recursive(object, indentation = 0)
   case object
   when Array
-    '{ "' + object.join('"; "') + '" }'
+    '{ ' + object.map {|v| print_recursive(v, 0)}.join(', ') + ' }'
   when Hash
     "{\n" + ' ' * (indentation + 2) + object.map {|k,v| "#{k} = " + print_recursive(v, indentation + 2)}.join(";\n" + ' ' * (indentation + 2)) + ";\n" + (' ' * indentation) + '}'
   when TrueClass, FalseClass


### PR DESCRIPTION

#### Pull Request (PR) description
Rendering of Arrays used ; instead of ,
Additionally with this fix, empty array are now rendered correct.

#### This Pull Request (PR) fixes the following issues
Fixes #88

